### PR TITLE
Austin/feat/mempool state cleanup

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1003,9 +1003,9 @@ std::string HelpMessage(HelpMessageMode mode) {
                     ));
     strUsage += HelpMessageOpt(
         "-blockprioritypercentage=<n>",
-        strprintf(_("Set maximum percentage of a block reserved to "
-                    "high-priority/low-fee transactions (default: %d). NOTE: This is supported only by the legacy block assembler which"
-                    " is not default block assembler any more and will be removed in the upcoming release."),
+        strprintf(_("Deprecated. Legacy priority-area block assembly has been "
+                    "removed; this option is parsed for compatibility but is "
+                    "not used by the journaling block assembler (default: %d)."),
                   DEFAULT_BLOCK_PRIORITY_PERCENTAGE));
     strUsage += HelpMessageOpt(
         "-blockmintxfee=<amt>",
@@ -1038,8 +1038,9 @@ std::string HelpMessage(HelpMessageMode mode) {
     /** Block assembler */
     strUsage += HelpMessageOpt(
         "-blockassembler=<type>",
-        strprintf(_("Set the type of block assembler to use for mining. Supported option is "
-                    "JOURNALING. (default: %s)"),
+        strprintf(_("Set the type of block assembler to use for mining. "
+                    "Supported option is JOURNALING. Legacy or unknown values "
+                    "fall back to the default. (default: %s)"),
                   enum_cast<std::string>(mining::DEFAULT_BLOCK_ASSEMBLER_TYPE).c_str()));
     strUsage += HelpMessageOpt( 
         "-jbamaxtxnbatch=<max batch size>",

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -21,6 +21,56 @@
 namespace
 {
     mining::CJournalChangeSetPtr nullChangeSet {nullptr};
+
+    CMutableTransaction MakeRootTx(size_t outputs = 1)
+    {
+        CMutableTransaction tx;
+        tx.vin.resize(1);
+        tx.vin[0].prevout = COutPoint(InsecureRand256(), 0);
+        tx.vin[0].scriptSig = CScript() << OP_11;
+        tx.vout.resize(outputs);
+        for (auto& out : tx.vout) {
+            out.scriptPubKey = CScript() << OP_11 << OP_EQUAL;
+            out.nValue = 10 * COIN;
+        }
+        return tx;
+    }
+
+    CMutableTransaction MakeChildTx(const CTransaction& parent,
+                                    uint32_t output = 0,
+                                    size_t outputs = 1)
+    {
+        CMutableTransaction tx;
+        tx.vin.resize(1);
+        tx.vin[0].prevout = COutPoint(parent.GetId(), output);
+        tx.vin[0].scriptSig = CScript() << OP_11;
+        tx.vout.resize(outputs);
+        for (auto& out : tx.vout) {
+            out.scriptPubKey = CScript() << OP_11 << OP_EQUAL;
+            out.nValue = 9 * COIN;
+        }
+        return tx;
+    }
+
+    CMutableTransaction MakeTwoParentTx(const CTransaction& parent1,
+                                        const CTransaction& parent2)
+    {
+        CMutableTransaction tx;
+        tx.vin.resize(2);
+        tx.vin[0].prevout = COutPoint(parent1.GetId(), 0);
+        tx.vin[0].scriptSig = CScript() << OP_11;
+        tx.vin[1].prevout = COutPoint(parent2.GetId(), 0);
+        tx.vin[1].scriptSig = CScript() << OP_11;
+        tx.vout.resize(1);
+        tx.vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
+        tx.vout[0].nValue = 8 * COIN;
+        return tx;
+    }
+
+    uint64_t InsertionIndex(const CTxMemPool& pool, const uint256& txid)
+    {
+        return pool.mapTx.find(txid)->GetInsertionIndex();
+    }
 }
 
 BOOST_FIXTURE_TEST_SUITE(mempool_tests, TestingSetup)
@@ -277,6 +327,64 @@ BOOST_AUTO_TEST_CASE(MempoolReorgReassignsInsertionIndex) {
 
     // After fixup the parent precedes the child topologically.
     BOOST_CHECK(pIdx() < cIdx());
+}
+
+BOOST_AUTO_TEST_CASE(MempoolReorgReassignsInsertionIndexForConnectedComponent) {
+    CTxMemPool pool;
+    TestMemPoolEntryHelper entry;
+
+    // Shape:
+    //
+    //   r
+    //   |-- a -- c
+    //   |-- b -- d        r/a/b are re-added from disconnected blocks after
+    //          c/d -- e   their descendants are already in the mempool.
+    //
+    // This covers the connected-component case rather than only a single
+    // parent/child edge: multiple resurrected ancestors, siblings, and a
+    // descendant with two in-mempool parents.
+    CMutableTransaction r = MakeRootTx(2);
+    CMutableTransaction a = MakeChildTx(CTransaction(r), 0);
+    CMutableTransaction b = MakeChildTx(CTransaction(r), 1);
+    CMutableTransaction c = MakeChildTx(CTransaction(a), 0);
+    CMutableTransaction d = MakeChildTx(CTransaction(b), 0);
+    CMutableTransaction e = MakeTwoParentTx(CTransaction(c), CTransaction(d));
+
+    // Existing mempool descendants. c/d can be present while a/b are still
+    // confirmed; e is then added normally and links to its in-mempool parents.
+    pool.AddUnchecked(c.GetId(), entry.Fee(Amount(10000LL)).FromTx(c), nullChangeSet);
+    pool.AddUnchecked(d.GetId(), entry.Fee(Amount(10000LL)).FromTx(d), nullChangeSet);
+    pool.AddUnchecked(e.GetId(), entry.Fee(Amount(10000LL)).FromTx(e), nullChangeSet);
+
+    // Disconnected-block transactions are resurrected after their descendants,
+    // which leaves their raw insertion order non-topological until the reorg
+    // fixup runs.
+    pool.AddUnchecked(r.GetId(), entry.Fee(Amount(10000LL)).FromTx(r), nullChangeSet);
+    pool.AddUnchecked(a.GetId(), entry.Fee(Amount(10000LL)).FromTx(a), nullChangeSet);
+    pool.AddUnchecked(b.GetId(), entry.Fee(Amount(10000LL)).FromTx(b), nullChangeSet);
+
+    BOOST_CHECK(InsertionIndex(pool, c.GetId()) < InsertionIndex(pool, a.GetId()));
+    BOOST_CHECK(InsertionIndex(pool, d.GetId()) < InsertionIndex(pool, b.GetId()));
+
+    std::vector<uint256> toUpdate{r.GetId(), a.GetId(), b.GetId()};
+    pool.UpdateTransactionsFromBlock(toUpdate, nullChangeSet);
+
+    BOOST_CHECK(InsertionIndex(pool, r.GetId()) < InsertionIndex(pool, a.GetId()));
+    BOOST_CHECK(InsertionIndex(pool, r.GetId()) < InsertionIndex(pool, b.GetId()));
+    BOOST_CHECK(InsertionIndex(pool, a.GetId()) < InsertionIndex(pool, c.GetId()));
+    BOOST_CHECK(InsertionIndex(pool, b.GetId()) < InsertionIndex(pool, d.GetId()));
+    BOOST_CHECK(InsertionIndex(pool, c.GetId()) < InsertionIndex(pool, e.GetId()));
+    BOOST_CHECK(InsertionIndex(pool, d.GetId()) < InsertionIndex(pool, e.GetId()));
+
+    CTxMemPool::setEntries descendants;
+    pool.CalculateDescendants(pool.mapTx.find(r.GetId()), descendants);
+    BOOST_CHECK_EQUAL(descendants.size(), 6UL);
+    BOOST_CHECK(descendants.count(pool.mapTx.find(r.GetId())));
+    BOOST_CHECK(descendants.count(pool.mapTx.find(a.GetId())));
+    BOOST_CHECK(descendants.count(pool.mapTx.find(b.GetId())));
+    BOOST_CHECK(descendants.count(pool.mapTx.find(c.GetId())));
+    BOOST_CHECK(descendants.count(pool.mapTx.find(d.GetId())));
+    BOOST_CHECK(descendants.count(pool.mapTx.find(e.GetId())));
 }
 
 BOOST_AUTO_TEST_CASE(MempoolAdmissionFeeCurveTest) {

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -13,6 +13,7 @@
 #include "consensus/merkle.h"
 #include "consensus/validation.h"
 #include "policy/policy.h"
+#include "pow.h"
 #include "pubkey.h"
 #include "script/script_num.h"
 #include "script/standard.h"
@@ -40,7 +41,7 @@ namespace
     {
     public:
         JournalingTestingSetup()
-            : TestingSetup(CBaseChainParams::MAIN, mining::CMiningFactory::BlockAssemblerType::JOURNALING)
+            : TestingSetup(CBaseChainParams::REGTEST, mining::CMiningFactory::BlockAssemblerType::JOURNALING)
         {}
     };
 
@@ -82,6 +83,14 @@ static struct {
     {2, 0xd351e722}, {1, 0xf4ca48c9}, {1, 0x5b19c670}, {1, 0xa164bf0e},
     {2, 0xbbbeb305}, {2, 0xfe1c810a},
 };
+
+CScript BuildCoinbaseScriptSig(int height, uint8_t extraNonce)
+{
+    CScript scriptSig;
+    scriptSig << CScriptNum(height);
+    scriptSig.push_back(extraNonce);
+    return scriptSig;
+}
 
 CBlockIndex CreateBlockIndex(int nHeight) {
     CBlockIndex index;
@@ -132,9 +141,8 @@ void Test_CreateNewBlock_validity(TestingSetup& testingSetup)
         pblock->nTime = chainActive.Tip()->GetMedianTimePast() + 1;
         CMutableTransaction txCoinbase(*pblock->vtx[0]);
         txCoinbase.nVersion = 1;
-        txCoinbase.vin[0].scriptSig = CScript();
-        txCoinbase.vin[0].scriptSig.push_back(blockinfo[i].extranonce);
-        txCoinbase.vin[0].scriptSig.push_back(chainActive.Height());
+        txCoinbase.vin[0].scriptSig =
+            BuildCoinbaseScriptSig(chainActive.Height(), blockinfo[i].extranonce);
         // Ignore the (optional) segwit commitment added by CreateNewBlock (as
         // the hardcoded nonces don't account for this)
         txCoinbase.vout.resize(1);
@@ -143,7 +151,11 @@ void Test_CreateNewBlock_validity(TestingSetup& testingSetup)
         if (txFirst.size() == 0) baseheight = chainActive.Height();
         if (txFirst.size() < 4) txFirst.push_back(pblock->vtx[0]);
         pblock->hashMerkleRoot = BlockMerkleRoot(*pblock);
-        pblock->nNonce = blockinfo[i].nonce;
+        pblock->nNonce = 0;
+        while (!CheckProofOfWork(pblock->GetHash(), pblock->nBits,
+                                 testingSetup.testConfig)) {
+            ++pblock->nNonce;
+        }
         std::shared_ptr<const CBlock> shared_pblock =
             std::make_shared<const CBlock>(*pblock);
         BOOST_CHECK(ProcessNewBlock(testingSetup.testConfig, shared_pblock, true, nullptr));
@@ -790,16 +802,19 @@ void Test_CreateNewBlock_JBA_Config(TestingSetup& testingSetup)
         pblock->nTime = chainActive.Tip()->GetMedianTimePast() + 1;
         CMutableTransaction txCoinbase(*pblock->vtx[0]);
         txCoinbase.nVersion = 1;
-        txCoinbase.vin[0].scriptSig = CScript();
-        txCoinbase.vin[0].scriptSig.push_back(blockinfo[i].extranonce);
-        txCoinbase.vin[0].scriptSig.push_back(chainActive.Height());
+        txCoinbase.vin[0].scriptSig =
+            BuildCoinbaseScriptSig(chainActive.Height(), blockinfo[i].extranonce);
         txCoinbase.vout.resize(1);
         txCoinbase.vout[0].scriptPubKey = CScript();
         pblock->vtx[0] = MakeTransactionRef(std::move(txCoinbase));
         if (txFirst.size() < 4)
             txFirst.push_back(pblock->vtx[0]);
         pblock->hashMerkleRoot = BlockMerkleRoot(*pblock);
-        pblock->nNonce = blockinfo[i].nonce;
+        pblock->nNonce = 0;
+        while (!CheckProofOfWork(pblock->GetHash(), pblock->nBits,
+                                 testingSetup.testConfig)) {
+            ++pblock->nNonce;
+        }
         std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(*pblock);
         BOOST_CHECK(ProcessNewBlock(testingSetup.testConfig, shared_pblock, true, nullptr));
         pblock->hashPrevBlock = pblock->GetHash();

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -284,11 +284,9 @@ public:
  *
  * CTxMemPool::mapTx, and CTxMemPoolEntry bookkeeping:
  *
- * mapTx is a boost::multi_index that sorts the mempool on 4 criteria:
+ * mapTx is a boost::multi_index that indexes the mempool by:
  * - transaction hash
- * - feerate [we use max(feerate of tx, feerate of tx with all descendants)]
  * - time in mempool
- * - mining score (feerate modified by any fee deltas from PrioritiseTransaction)
  *
  * Note: mapTx will become private and may be modified extensively in the future. It will
  * not be part of the public definition of this class.
@@ -297,13 +295,8 @@ public:
  * this one, while "ancestor" refers to in-mempool transactions that a given
  * transaction depends on.
  *
- * Note: the feerate sort (referenced below) will be removed in future.
- * In order for the feerate sort to remain correct, we must update transactions
- * in the mempool when new descendants arrive. To facilitate this, we track the
- * set of in-mempool direct parents and direct children in mapLinks. Within each
- * CTxMemPoolEntry, we track the size and fees of all descendants.
- *
- * Note: tracking of ancestors and descendants may be removed in the future.
+ * We track the set of in-mempool direct parents and direct children in mapLinks.
+ * Aggregate ancestor/descendant size, fee and count totals are not cached.
  *
  * Usually when a new transaction is added to the mempool, it has no in-mempool
  * children (because any such children would be an orphan). So in
@@ -617,11 +610,10 @@ public:
 
     /**
      * Try to calculate all in-mempool ancestors of entry.
-     *  (these are all calculated including the tx itself)
-     *  limitAncestorCount = max number of ancestors
-     *  limitAncestorSize = max size of ancestors
-     *  limitDescendantCount = max number of descendants any ancestor can have
-     *  limitDescendantSize = max size of descendants any ancestor can have
+     *  limitAncestorCount = max ancestor chain height
+     *  limitAncestorSize = deprecated; retained for API compatibility
+     *  limitDescendantCount = deprecated; retained for API compatibility
+     *  limitDescendantSize = deprecated; retained for API compatibility
      *  errString = populated with error reason if any limits are hit
      * fSearchForParents = whether to search a tx's vin for in-mempool parents,
      * or look up parents from mapLinks. Must be true for entries not in the
@@ -819,8 +811,10 @@ private:
     // - only transactions for which filter returns true are considered
     // - every transaction from the set will have all its in-mempool ancestors included in the set (if they pass filter)
     // - if the limit is not std::nullopt, not all children/siblings will be added. adding new transactions to the set is stopped when the size of the 
-    //   entries set is reached, but we have to ensure that all parents of all transactions in the set, so
-    //   we have to add parents of the last added entry too, this can extend the size of the entries set by up to {-limitdescendantcount - 1} transactions
+    //   entries set is reached, but we have to ensure that all parents of all
+    //   transactions in the set, so we have to add parents of the last added
+    //   entry too. Because ancestor inclusion is mandatory, the returned set can
+    //   exceed the limit.
     setEntries getConnectedNL(const setEntries& entries, std::function<bool(txiter)> filter, std::optional<size_t> limit= std::nullopt) const;
     
     // returns a set of entries which are connected to any of items in the given set, but not elements of the given set.

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2562,9 +2562,8 @@ bool CWallet::SelectCoins(
         }
     }
 
-    size_t nMaxChainLength = std::min(
-        gArgs.GetArg("-limitancestorcount", DEFAULT_ANCESTOR_LIMIT),
-        gArgs.GetArg("-limitdescendantcount", DEFAULT_DESCENDANT_LIMIT));
+    size_t nMaxChainLength =
+        gArgs.GetArg("-limitancestorcount", DEFAULT_ANCESTOR_LIMIT);
     bool fRejectLongChains = gArgs.GetBoolArg(
         "-walletrejectlongchains", DEFAULT_WALLET_REJECT_LONG_CHAINS);
 

--- a/test/functional/abc-high_priority_transaction.py
+++ b/test/functional/abc-high_priority_transaction.py
@@ -9,8 +9,6 @@
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
-from test_framework.mininode import COIN
-from test_framework.cdefs import LEGACY_MAX_BLOCK_SIZE, COINBASE_MATURITY
 
 
 class HighPriorityTransactionTest(BitcoinTestFramework):
@@ -19,86 +17,17 @@ class HighPriorityTransactionTest(BitcoinTestFramework):
         self.num_nodes = 1
         self.extra_args = [["-blockprioritypercentage=0", "-limitfreerelay=2", "-blockassembler=legacy"]]
 
-    def create_small_transactions(self, node, utxos, num, fee):
-        addr = node.getnewaddress()
-        txids = []
-        for _ in range(num):
-            t = utxos.pop()
-            inputs = [{"txid": t["txid"], "vout": t["vout"]}]
-            outputs = {}
-            change = t['amount'] - fee
-            outputs[addr] = satoshi_round(change)
-            rawtx = node.createrawtransaction(inputs, outputs)
-            signresult = node.signrawtransaction(
-                rawtx, None, None, "NONE|FORKID")
-            txid = node.sendrawtransaction(signresult["hex"], True)
-            txids.append(txid)
-        return txids
-
-    def generate_high_priotransactions(self, node, count):
-        # generate a bunch of spendable utxos
-        self.txouts = gen_return_txouts()
-        # create 150 simple one input one output hi prio txns
-        hiprio_utxo_count = 150
-        age = 250
-        # be sure to make this utxo aged enough
-        hiprio_utxos = create_confirmed_utxos(
-            self.relayfee, node, hiprio_utxo_count, age)
-        txids = []
-
-        # Create hiprio_utxo_count number of txns with 0 fee
-        range_size = [0, hiprio_utxo_count]
-        start_range = range_size[0]
-        end_range = range_size[1]
-        txids = self.create_small_transactions(
-            node, hiprio_utxos[start_range:end_range], end_range - start_range, 0)
-        return txids
-
     def run_test(self):
-        # this is the priority cut off as defined in AllowFreeThreshold() (see: src/txmempool.h)
-        # anything above that value is considered an high priority transaction
-        hiprio_threshold = COIN * 144 / 250
-        self.relayfee = self.nodes[0].getnetworkinfo()['relayfee']
-
-        # first test step: 0 reserved prio space in block
-        txids = self.generate_high_priotransactions(self.nodes[0], 150)
-        mempool_size_pre = self.nodes[0].getmempoolinfo()['bytes']
-        mempool = self.nodes[0].getrawmempool(True)
-        # assert that all the txns are in the mempool and that all of them are hi prio
-        for i in txids:
-            assert(i in mempool)
-            assert(mempool[i]['currentpriority'] > hiprio_threshold)
-
-        # mine one block
+        # Legacy priority-area block assembly has been removed. The legacy
+        # assembler option and blockprioritypercentage are accepted for
+        # compatibility and fall back to the journaling assembler.
         self.nodes[0].generate(1)
 
-        self.log.info(
-            "Assert that all high prio transactions haven't been mined")
-        assert_equal(self.nodes[0].getmempoolinfo()['bytes'], mempool_size_pre)
-
-        # restart with default blockprioritypercentage
         self.stop_nodes()
         self.nodes = []
         self.add_nodes(self.num_nodes, [["-limitfreerelay=2", "-blockassembler=legacy"]])
         self.start_nodes()
-
-        # second test step: default reserved prio space in block (100K).
-        # the mempool size is about 25K this means that all txns will be
-        # included in the soon to be mined block
-        txids = self.generate_high_priotransactions(self.nodes[0], 150)
-        mempool_size_pre = self.nodes[0].getmempoolinfo()['bytes']
-        mempool = self.nodes[0].getrawmempool(True)
-        # assert that all the txns are in the mempool and that all of them are hiprio
-        for i in txids:
-            assert(i in mempool)
-            assert(mempool[i]['currentpriority'] > hiprio_threshold)
-
-        # mine one block
         self.nodes[0].generate(1)
-
-        self.log.info("Assert that all high prio transactions have been mined")
-        i = self.nodes[0].getmempoolinfo()
-        assert(self.nodes[0].getmempoolinfo()['bytes'] == 0)
 
 
 if __name__ == '__main__':

--- a/test/functional/bsv-mempool_ancestorsizelimit.py
+++ b/test/functional/bsv-mempool_ancestorsizelimit.py
@@ -7,13 +7,9 @@ from test_framework.util import *
 from test_framework.mininode import *
 from test_framework.script import CScript, OP_TRUE, OP_RETURN
 
-# Test if -limitancestorsize and -limitdescendantsize settings work as expected.
-# Ancestors:
-# Sum of transactions's ancestors' sizes in a mempool should not exceed limitancestorsize.
-# A chain of transactions is sent to bitcoind in that order: fundingTransaction -> tx1 -> tx2 -> tx3 ...
-# Descendants:
-# Sum of transactions's descendants' sizes in a mempool should not exceed limitdescendantsize.
-# A funding transaction with 10 outputs is sent to bitcoind, after that children with the same parent are sent.
+# Test that -limitancestorsize and -limitdescendantsize are retained as
+# compatibility options but no longer enforce mempool admission limits. Mempool
+# chain policy is based on ancestor height only.
 
 class MempoolSizeLimitTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -25,7 +21,7 @@ class MempoolSizeLimitTest(BitcoinTestFramework):
 
     # Build and submit a transaction that spends parent_txid:vout
     # Return amount sent
-    def chain_transaction(self, node, parent_txid, vout, value, num_outputs, connection):
+    def chain_transaction(self, node, parent_txid, vout, value, num_outputs):
         fee = 300
         send_value = (value - fee) / num_outputs
 
@@ -36,7 +32,7 @@ class MempoolSizeLimitTest(BitcoinTestFramework):
         # Append some data, so that transactions are larger
         tx.vout.append(CTxOut(int(0), CScript([OP_RETURN,  b"a" * 200])))
         tx.rehash()
-        connection.send_message(msg_tx(tx))
+        node.sendrawtransaction(ToHex(tx))
    
         txSize = len(tx.serialize())
         return (tx, send_value, txSize)
@@ -45,20 +41,8 @@ class MempoolSizeLimitTest(BitcoinTestFramework):
         # 0. Prepare initial blocks.
         self.nodes[0].generate(101)
 
-        rejected_txs = []
-        def on_reject(conn, msg):
-            rejected_txs.append(msg)
-
-        connection = NodeConnCB()
-        connections = []
-        connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], connection))
-        connection.add_connection(connections[0])
-        connection.on_reject = on_reject
-        NetworkThread().start()
-        connection.wait_for_verack()
-
         ######################################
-        # 1. Test ancestor chain size limit.
+        # 1. Ancestor size does not reject transactions.
         # First create funding transaction that pays to output that does not require signatures.
         out_value = 10000
         ftx = CTransaction()
@@ -67,77 +51,64 @@ class MempoolSizeLimitTest(BitcoinTestFramework):
         ftxHex = self.nodes[0].signrawtransaction(ftxHex)['hex']
         ftx = FromHex(CTransaction(), ftxHex)
         ftx.rehash()
-        connection.send_message(msg_tx(ftx))
+        self.nodes[0].sendrawtransaction(ftxHex)
+        wait_until(lambda: ftx.hash in self.nodes[0].getrawmempool(), timeout=5)
         ancestorsSize = len(ftxHex)/2
         txid = ftx.sha256
         value = out_value
 
-        # For loop will take less than MAX_ANCESOTS iterations.
-        # That way we make sure that exception is not caused by ancestor limit count.
+        # Build enough transactions to exceed the configured ancestor-size value
+        # while staying below the default ancestor-height limit.
         MAX_ANCESTORS = 25
-        for i in range (0, MAX_ANCESTORS):
-            (tx, sent_value, txSize) = self.chain_transaction(self.nodes[0], txid, 0, value, 1, connection)
+        exceededAncestorSize = False
+        for i in range(0, MAX_ANCESTORS - 1):
+            (tx, sent_value, txSize) = self.chain_transaction(self.nodes[0], txid, 0, value, 1)
             txid = tx.sha256
             value = sent_value
             ancestorsSize = ancestorsSize + txSize
+            wait_until(lambda: tx.hash in self.nodes[0].getrawmempool(), timeout=5)
 
-            # Check if next sent transaction will cause too many ancestors in a mempool.
-            # The same exception is thrown either if the count of ancestors is too large or the size of all ancestors is too large.
-            # Here, the size is the problem (count is less then limitancestorcount, which is 25 by default).
-            if (ancestorsSize + txSize > self.limitancestorsize):
-                (tx, sent_value, txSize) = self.chain_transaction(self.nodes[0], txid, 0, value, 1, connection)
-                connection.wait_for_reject()
+            if ancestorsSize > self.limitancestorsize:
+                exceededAncestorSize = True
                 break
 
-        assert_equal(len(rejected_txs), 1)
-        assert_equal(rejected_txs[0].data, tx.sha256)
-        assert_equal(rejected_txs[0].reason, b'too-long-mempool-chain')
+        assert(exceededAncestorSize)
 
         ######################################
-        # 2. Test descendant chain size limit.
+        # 2. Descendant size does not reject transactions.
         send_value = 10000
    
         ftx = CTransaction()
-        for i in range(10):
+        MAX_DESCENDANTS = 25
+        for i in range(MAX_DESCENDANTS):
             ftx.vout.append(CTxOut(send_value, CScript([OP_TRUE])))
         ftxHex = self.nodes[0].fundrawtransaction(ToHex(ftx),{ 'changePosition' : len(ftx.vout)})['hex'] 
         ftxHex = self.nodes[0].signrawtransaction(ftxHex)['hex']
         ftx = FromHex(CTransaction(), ftxHex)
         ftx.rehash()
         descendantsSize = len(ftxHex)/2
-        connection.send_message(msg_tx(ftx))
+        self.nodes[0].sendrawtransaction(ftxHex)
 
         utxos = []
-        for i in range(10):
+        for i in range(MAX_DESCENDANTS):
             utxos.append({'txid': ftx.sha256, 'vout': i, 'amount': send_value})
 
-        # For loop will take less than MAX_DESCENDANTS iterations.
-        # That way we make sure that exception is not caused by descendant limit count.
-        MAX_DESCENDANTS = 25
-        # Keep txids from the produced chain.
-        chain_of_descendant_txns = []
+        wait_until(lambda: ftx.hash in self.nodes[0].getrawmempool(), timeout=5)
+
+        # Build enough siblings to exceed the configured descendant-size value.
+        # Siblings avoid the ancestor-height limit, isolating the deprecated
+        # descendant-size option.
+        exceededDescendantSize = False
         for i in range(MAX_DESCENDANTS):
             utxo = utxos.pop(0)
-            (tx, sent_value, txSize) = self.chain_transaction(self.nodes[0], utxo['txid'], utxo['vout'], utxo['amount'], 1, connection)
+            (tx, sent_value, txSize) = self.chain_transaction(self.nodes[0], utxo['txid'], utxo['vout'], utxo['amount'], 1)
             descendantsSize = descendantsSize + txSize
-            chain_of_descendant_txns.append(tx.sha256)
-            # Check if next sent transaction will cause too many descendants in a mempool.
-            # The same exception is thrown either if the count of descendants is too large or the size of all descendants is too large.
-            # Here, the size is the problem (count is less then limitdescendantscount, which is 25 by default).
-            if (descendantsSize + txSize > self.limitdescendantsize):
-                utxo = utxos.pop(0)
-                connection.clear_messages()
-                # Check if there is an expected number of transactions in the mempool.
-                wait_until(lambda: len(self.nodes[0].getrawmempool()) == i, timeout=1)
-                (tx, sent_value, txSize) = self.chain_transaction(self.nodes[0], utxo['txid'], utxo['vout'], utxo['amount'], 1, connection)
-                chain_of_descendant_txns.append(tx.sha256)
-                connection.wait_for_reject()
+            wait_until(lambda: tx.hash in self.nodes[0].getrawmempool(), timeout=5)
+            if descendantsSize > self.limitdescendantsize:
+                exceededDescendantSize = True
                 break
 
-        assert_equal(len(rejected_txs), 2)
-        # Evaluation order of siblings is random
-        assert(rejected_txs[1].data in chain_of_descendant_txns)
-        assert_equal(rejected_txs[1].reason, b'too-long-mempool-chain')
+        assert(exceededDescendantSize)
 
 if __name__ == '__main__':
     MempoolSizeLimitTest().main()

--- a/test/functional/mempool_packages.py
+++ b/test/functional/mempool_packages.py
@@ -256,6 +256,14 @@ class MempoolPackagesTest(BitcoinTestFramework):
         self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())
         sync_blocks(self.nodes)
 
+        node1_mempool = self.nodes[1].getrawmempool()
+        assert(tx1_id in node1_mempool)
+        assert(txid not in node1_mempool)
+
+        # Node0 does not have the tight ancestor limit, so the disconnected
+        # chain and its high-fee dependent transaction survive reorg replay.
+        assert(txid in self.nodes[0].getrawmempool())
+
 
 if __name__ == '__main__':
     MempoolPackagesTest().main()

--- a/test/functional/mempool_packages.py
+++ b/test/functional/mempool_packages.py
@@ -2,26 +2,31 @@
 # Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test descendant package tracking code."""
+"""Test mempool ancestor/descendant queries and unconfirmed-chain limits."""
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
-from test_framework.mininode import COIN
 
 MAX_ANCESTORS = 25
 MAX_DESCENDANTS = 25
+TBCCOIN = 1000000
+
+
+def tbc_round(amount):
+    return Decimal(amount).quantize(Decimal('0.000001'), rounding=ROUND_DOWN)
 
 
 class MempoolPackagesTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
-        self.extra_args = [["-maxorphantx=1000"],
-                           ["-maxorphantx=1000", "-limitancestorcount=5"]]
+        self.extra_args = [["-maxorphantx=1000", "-checkmempool=0"],
+                           ["-maxorphantx=1000", "-checkmempool=0",
+                            "-limitancestorcount=5"]]
 
     # Build a transaction that spends parent_txid:vout
     # Return amount sent
     def chain_transaction(self, node, parent_txid, vout, value, fee, num_outputs):
-        send_value = satoshi_round((value - fee) / num_outputs)
+        send_value = tbc_round((value - fee) / num_outputs)
         inputs = [{'txid': parent_txid, 'vout': vout}]
         outputs = {}
         for i in range(num_outputs):
@@ -33,6 +38,18 @@ class MempoolPackagesTest(BitcoinTestFramework):
         # make sure we didn't generate a change output
         assert(len(fulltx['vout']) == num_outputs)
         return (txid, send_value)
+
+    def assert_removed_package_fields(self, entry):
+        removed_fields = [
+            'ancestorcount',
+            'ancestorsize',
+            'ancestorfees',
+            'descendantcount',
+            'descendantsize',
+            'descendantfees',
+        ]
+        for field in removed_fields:
+            assert(field not in entry)
 
     def run_test(self):
         ''' Mine some blocks and have them mature. '''
@@ -51,13 +68,11 @@ class MempoolPackagesTest(BitcoinTestFramework):
             value = sent_value
             chain.append(txid)
 
-        # Check mempool has MAX_ANCESTORS transactions in it, and descendant
-        # count and fees should look correct
+        # Check mempool has MAX_ANCESTORS transactions in it. The ancestor and
+        # descendant aggregate fields were removed from verbose mempool RPCs;
+        # dynamic ancestor/descendant query RPCs should still work.
         mempool = self.nodes[0].getrawmempool(True)
         assert_equal(len(mempool), MAX_ANCESTORS)
-        descendant_count = 1
-        descendant_fees = 0
-        descendant_size = 0
 
         descendants = []
         ancestors = list(chain)
@@ -65,15 +80,8 @@ class MempoolPackagesTest(BitcoinTestFramework):
             # Check that getmempoolentry is consistent with getrawmempool
             entry = self.nodes[0].getmempoolentry(x)
             assert_equal(entry, mempool[x])
-
-            # Check that the descendant calculations are correct
-            assert_equal(mempool[x]['descendantcount'], descendant_count)
-            descendant_fees += mempool[x]['fee']
+            self.assert_removed_package_fields(entry)
             assert_equal(mempool[x]['modifiedfee'], mempool[x]['fee'])
-            assert_equal(mempool[x]['descendantfees'], descendant_fees * COIN)
-            descendant_size += mempool[x]['size']
-            assert_equal(mempool[x]['descendantsize'], descendant_size)
-            descendant_count += 1
 
             # Check that getmempooldescendants is correct
             assert_equal(sorted(descendants), sorted(
@@ -98,33 +106,21 @@ class MempoolPackagesTest(BitcoinTestFramework):
             assert_equal(mempool[x], v_descendants[x])
         assert(chain[0] not in v_descendants.keys())
 
-        # Check that ancestor modified fees includes fee deltas from
-        # prioritisetransaction
+        # Check that fee deltas still update the transaction's modified fee.
         self.nodes[0].prioritisetransaction(chain[0], 0, 1000)
         mempool = self.nodes[0].getrawmempool(True)
-        ancestor_fees = 0
-        for x in chain:
-            ancestor_fees += mempool[x]['fee']
-            assert_equal(mempool[x]['ancestorfees'],
-                         ancestor_fees * COIN + 1000)
+        assert_equal(mempool[chain[0]]['modifiedfee'],
+                     mempool[chain[0]]['fee'] + Decimal(1000) / TBCCOIN)
+        self.assert_removed_package_fields(mempool[chain[0]])
 
         # Undo the prioritisetransaction for later tests
         self.nodes[0].prioritisetransaction(chain[0], 0, -1000)
 
-        # Check that descendant modified fees includes fee deltas from
-        # prioritisetransaction
         self.nodes[0].prioritisetransaction(chain[-1], 0, 1000)
         mempool = self.nodes[0].getrawmempool(True)
-
-        descendant_fees = 0
-        for x in reversed(chain):
-            descendant_fees += mempool[x]['fee']
-            assert_equal(mempool[x]['descendantfees'],
-                         descendant_fees * COIN + 1000)
-
-        # Adding one more transaction on to the chain should fail.
-        assert_raises_rpc_error(-26, "too-long-mempool-chain",
-                                self.chain_transaction, self.nodes[0], txid, vout, value, fee, 1)
+        assert_equal(mempool[chain[-1]]['modifiedfee'],
+                     mempool[chain[-1]]['fee'] + Decimal(1000) / TBCCOIN)
+        self.assert_removed_package_fields(mempool[chain[-1]])
 
         # Check that prioritising a tx before it's added to the mempool works
         # First clear the mempool by mining a block.
@@ -141,50 +137,53 @@ class MempoolPackagesTest(BitcoinTestFramework):
         # Now check that the transaction is in the mempool, with the right modified fee
         mempool = self.nodes[0].getrawmempool(True)
 
-        descendant_fees = 0
         for x in reversed(chain):
-            descendant_fees += mempool[x]['fee']
             if (x == chain[-1]):
                 assert_equal(mempool[x]['modifiedfee'],
-                             mempool[x]['fee'] + satoshi_round(0.00002))
-            assert_equal(mempool[x]['descendantfees'],
-                         descendant_fees * COIN + 2000)
+                             mempool[x]['fee'] + Decimal(2000) / TBCCOIN)
+            self.assert_removed_package_fields(mempool[x])
 
         # TODO: check that node1's mempool is as expected
 
         # TODO: test ancestor size limits
 
-        # Now test descendant chain limits
-        txid = utxo[1]['txid']
-        value = utxo[1]['amount']
-        vout = utxo[1]['vout']
+        # Descendant count limits are no longer enforced. Ancestor height is
+        # still enforced, so use a fan-out package that grows descendants
+        # without creating a chain deeper than the ancestor limit.
+        descendant_utxo = max(self.nodes[0].listunspent(1),
+                              key=lambda u: u['amount'])
+        txid = descendant_utxo['txid']
+        value = descendant_utxo['amount']
+        vout = descendant_utxo['vout']
 
         transaction_package = []
-        # First create one parent tx with 10 children
+        # First create one parent tx with enough outputs for many direct
+        # descendants.
         (txid, sent_value) = self.chain_transaction(
-            self.nodes[0], txid, vout, value, fee, 10)
+            self.nodes[0], txid, vout, value, fee, MAX_DESCENDANTS + 1)
         parent_transaction = txid
-        for i in range(10):
+        for i in range(MAX_DESCENDANTS + 1):
             transaction_package.append(
                 {'txid': txid, 'vout': i, 'amount': sent_value})
 
-        # Sign and send up to MAX_DESCENDANT transactions chained off the parent tx
+        # Sign and send up to the legacy descendant limit as direct children of
+        # the parent transaction.
         for i in range(MAX_DESCENDANTS - 1):
             utxo = transaction_package.pop(0)
             (txid, sent_value) = self.chain_transaction(
-                self.nodes[0], utxo['txid'], utxo['vout'], utxo['amount'], fee, 10)
-            for j in range(10):
-                transaction_package.append(
-                    {'txid': txid, 'vout': j, 'amount': sent_value})
+                self.nodes[0], utxo['txid'], utxo['vout'], utxo['amount'], fee, 1)
 
-        mempool = self.nodes[0].getrawmempool(True)
-        assert_equal(mempool[parent_transaction]
-                     ['descendantcount'], MAX_DESCENDANTS)
+        assert_equal(len(self.nodes[0].getmempooldescendants(parent_transaction)),
+                     MAX_DESCENDANTS - 1)
 
-        # Sending one more chained transaction will fail
+        # Sending one more descendant succeeds because descendant count limits
+        # are no longer enforced.
         utxo = transaction_package.pop(0)
-        assert_raises_rpc_error(-26, "too-long-mempool-chain", self.chain_transaction,
-                                self.nodes[0], utxo['txid'], utxo['vout'], utxo['amount'], fee, 10)
+        (txid, sent_value) = self.chain_transaction(
+            self.nodes[0], utxo['txid'], utxo['vout'], utxo['amount'], fee, 1)
+        assert(txid in self.nodes[0].getrawmempool())
+        assert_equal(len(self.nodes[0].getmempooldescendants(parent_transaction)),
+                     MAX_DESCENDANTS)
 
         # TODO: check that node1's mempool is as expected
 

--- a/test/functional/prioritise_transaction.py
+++ b/test/functional/prioritise_transaction.py
@@ -9,9 +9,11 @@
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
-# FIXME: review how this test needs to be adapted w.r.t _LEGACY_MAX_BLOCK_SIZE
 from test_framework.mininode import COIN
-from test_framework.cdefs import LEGACY_MAX_BLOCK_SIZE, ONE_KILOBYTE
+
+
+def tbc_round(amount):
+    return Decimal(amount).quantize(Decimal('0.000001'), rounding=ROUND_DOWN)
 
 
 class PrioritiseTransactionTest(BitcoinTestFramework):
@@ -23,146 +25,20 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
         self.setup_clean_chain = True
         self.num_nodes = 1
 
-    def run_legacy_test(self):
-        self.start_node(0, ["-printpriority=1", "-blockmaxsize=32000000", "-blockassembler=legacy"], )
-
-        self.txouts = gen_return_txouts()
-        self.relayfee = self.nodes[0].getnetworkinfo()['relayfee']
-
-        # Create enough UTXOs to fill the 3 blocks we need for this test
-        utxo_count = 1440
-        utxos = create_confirmed_utxos(
-            self.relayfee, self.nodes[0], utxo_count)
-        # our transactions are smaller than 100kb
-        base_fee = self.relayfee * 100
-        txids = []
-
-        # Create 3 batches of transactions at 3 different fee rate levels
-        range_size = utxo_count // 3
-        for i in range(3):
-            txids.append([])
-            start_range = i * range_size
-            end_range = start_range + range_size
-            txids[i] = create_lots_of_big_transactions(self.nodes[0], self.txouts, utxos[
-                                                       start_range:end_range], end_range - start_range, (i + 1) * base_fee)
-
-        # Make sure that the size of each group of transactions exceeds
-        # LEGACY_MAX_BLOCK_SIZE -- otherwise the test needs to be revised to create
-        # more transactions.
-        mempool = self.nodes[0].getrawmempool(True)
-        sizes = [0, 0, 0]
-        for i in range(3):
-            for j in txids[i]:
-                assert(j in mempool)
-                sizes[i] += mempool[j]['size']
-            # Fail => raise utxo_count
-            assert(sizes[i] > LEGACY_MAX_BLOCK_SIZE)
-
-        # add a fee delta to something in the cheapest bucket and make sure it gets mined
-        # also check that a different entry in the cheapest bucket is NOT mined (lower
-        # the priority to ensure its not mined due to priority)
-        self.nodes[0].prioritisetransaction(
-            txids[0][0], 0, int(3 * base_fee * COIN))
-        self.nodes[0].prioritisetransaction(txids[0][1], -1e15, 0)
-
+    def run_legacy_option_compatibility_test(self):
+        self.start_node(0, ["-blockassembler=legacy"])
         self.nodes[0].generate(1)
-
-        mempool = self.nodes[0].getrawmempool()
-        self.log.info("Assert that prioritised transaction was mined")
-        assert(txids[0][0] not in mempool)
-        assert(txids[0][1] in mempool)
-
-        high_fee_tx = None
-        for x in txids[2]:
-            if x not in mempool:
-                high_fee_tx = x
-
-        # Something high-fee should have been mined!
-        assert(high_fee_tx != None)
-
-        # Add a prioritisation before a tx is in the mempool (de-prioritising a
-        # high-fee transaction so that it's now low fee).
-        self.nodes[0].prioritisetransaction(
-            high_fee_tx, -1e15, -int(2 * base_fee * COIN))
-
-        # Add everything back to mempool
-        self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())
-
-        # Check to make sure our high fee rate tx is back in the mempool
-        mempool = self.nodes[0].getrawmempool()
-        assert(high_fee_tx in mempool)
-
-        # Now verify the modified-high feerate transaction isn't mined before
-        # the other high fee transactions. Keep mining until our mempool has
-        # decreased by all the high fee size that we calculated above.
-        while (self.nodes[0].getmempoolinfo()['bytes'] > sizes[0] + sizes[1]):
-            self.nodes[0].generate(1)
-
-        # High fee transaction should not have been mined, but other high fee rate
-        # transactions should have been.
-        mempool = self.nodes[0].getrawmempool()
-        self.log.info(
-            "Assert that de-prioritised transaction is still in mempool")
-        assert(high_fee_tx in mempool)
-        for x in txids[2]:
-            if (x != high_fee_tx):
-                assert(x not in mempool)
-
-        # Create a free, low priority transaction.  Should be rejected.
-        utxo_list = self.nodes[0].listunspent()
-        assert(len(utxo_list) > 0)
-        utxo = utxo_list[0]
-
-        inputs = []
-        outputs = {}
-        inputs.append({"txid": utxo["txid"], "vout": utxo["vout"]})
-        outputs[self.nodes[0].getnewaddress()] = utxo["amount"] - self.relayfee
-        raw_tx = self.nodes[0].createrawtransaction(inputs, outputs)
-        tx_hex = self.nodes[0].signrawtransaction(raw_tx)["hex"]
-        txid = self.nodes[0].sendrawtransaction(tx_hex)
-
-        # A tx that spends an in-mempool tx has 0 priority, so we can use it to
-        # test the effect of using prioritise transaction for mempool
-        # acceptance
-        inputs = []
-        inputs.append({"txid": txid, "vout": 0})
-        outputs = {}
-        outputs[self.nodes[0].getnewaddress()] = utxo["amount"] - self.relayfee
-        raw_tx2 = self.nodes[0].createrawtransaction(inputs, outputs)
-        tx2_hex = self.nodes[0].signrawtransaction(raw_tx2)["hex"]
-        tx2_id = self.nodes[0].decoderawtransaction(tx2_hex)["txid"]
-
-        # This will raise an exception due to mempool minimum fee not being met
-        assert_raises_rpc_error(-26, "66: insufficient priority",
-                                self.nodes[0].sendrawtransaction, tx2_hex)
-        assert(tx2_id not in self.nodes[0].getrawmempool())
-
-        # This is a less than 1000-byte transaction, so just set the fee
-        # to be the minimum for a 1000 byte transaction and check that it is
-        # accepted.
-        self.nodes[0].prioritisetransaction(
-            tx2_id, 0, int(self.relayfee * COIN))
-
-        self.log.info(
-            "Assert that prioritised free transaction is accepted to mempool")
-        assert_equal(self.nodes[0].sendrawtransaction(tx2_hex), tx2_id)
-        assert(tx2_id in self.nodes[0].getrawmempool())
-
         self.stop_node(0)
 
     def run_journaling_test(self):
-        self.start_node(0, ["-blockmintxfee=0.00003"] )
+        self.start_node(0, ["-blockmintxfee=0.01"] )
 
         node = self.nodes[0]
         self.txouts = gen_return_txouts()
 
         utxo = create_confirmed_utxos(Decimal(1000)/Decimal(COIN), node, 1, age=101)[0]
 
-        relayfeerate = self.nodes[0].getnetworkinfo()['relayfee']
-
-        ESTIMATED_TX_SIZE_IN_KB = Decimal(385)/Decimal(ONE_KILOBYTE)
-
-        relayfee = ESTIMATED_TX_SIZE_IN_KB * relayfeerate
+        relayfee = Decimal('0.002')
 
         low_paying_txs = []
 
@@ -170,15 +46,14 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
         # let's create a chain of three low paying transactions and sent them to the node, they end up in the mempool
         for _ in range(3):
             inputs = [{"txid": utxo["txid"], "vout": utxo["vout"]}]
-            outputs = {node.getnewaddress(): satoshi_round(utxo['amount'] - relayfee)}
+            outputs = {node.getnewaddress(): tbc_round(utxo['amount'] - relayfee)}
             rawtx = node.createrawtransaction(inputs, outputs)
             signed_tx = node.signrawtransaction(rawtx)["hex"]
-            x = len(signed_tx)
             txid = node.sendrawtransaction(signed_tx)
             low_paying_txs.append(txid)
             assert txid in node.getrawmempool()
             tx_info = node.getrawtransaction(txid, True)
-            utxo = {"txid":txid, "vout":0, "amount":tx_info["vout"][0]["value"]}
+            utxo = {"txid": txid, "vout": 0, "amount": tx_info["vout"][0]["value"]}
 
 
         node.generate(1)
@@ -204,7 +79,7 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
 
 
     def run_test(self):
-        self.run_legacy_test()
+        self.run_legacy_option_compatibility_test()
         self.run_journaling_test()
 
 if __name__ == '__main__':

--- a/test/functional/tbc-wallet-chainlimit-descendant-ignored.py
+++ b/test/functional/tbc-wallet-chainlimit-descendant-ignored.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 TBC developers
+# Distributed under the Open TBC software license, see the accompanying file LICENSE.
+"""Test wallet chain-limit selection ignores deprecated descendant limit."""
+
+from decimal import Decimal
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal, wait_until
+
+
+class WalletDescendantLimitIgnoredTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+        self.extra_args = [[
+            "-walletrejectlongchains",
+            "-limitancestorcount=10",
+            "-limitdescendantcount=1",
+        ]]
+
+    def run_test(self):
+        node = self.nodes[0]
+        node.generate(101)
+
+        # Consolidate mature balance into one confirmed wallet output so
+        # subsequent sends have to spend unconfirmed change.
+        self_addr = node.getnewaddress()
+        consolidate_txid = node.sendtoaddress(
+            self_addr, node.getbalance(), "", "", True)
+        node.generate(1)
+        assert(consolidate_txid not in node.getrawmempool())
+
+        dest = node.getnewaddress()
+        txids = []
+        for _ in range(3):
+            txid = node.sendtoaddress(dest, Decimal("0.0001"))
+            txids.append(txid)
+            wait_until(lambda: txid in node.getrawmempool(), timeout=5)
+
+        assert_equal(len(set(txids).intersection(set(node.getrawmempool()))), 3)
+
+
+if __name__ == '__main__':
+    WalletDescendantLimitIgnoredTest().main()


### PR DESCRIPTION
This branch cleans up mempool state tracking by removing cached ancestor/descendant aggregate fields and moving ordering-sensitive paths to explicit topology based on insertionIndex. It also updates mempool admission policy to no-trim behavior with a size-based fee ramp, refreshes related RPC/functional coverage, and removes stale legacy assumptions from mining/journal tests.
Additional coverage was added for reorg replay: disconnected-block transactions re-added beneath existing mempool descendants now restore topological insertionIndex across a connected component, and mempool_packages.py now asserts the expected post-reorg mempool state under tight ancestor limits.