### PR TITLE
fix: refresh mempool ancestor heights after reorg

### DIFF
--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -435,6 +435,7 @@ BOOST_AUTO_TEST_CASE(MempoolReorgReassignsInsertionIndex) {
     // point), then the parent is re-added -- mimicking a block disconnect that
     // re-adds the parent underneath an existing child.
     pool.AddUnchecked(c.GetId(), entry.Fee(Amount(10000LL)).FromTx(c), nullChangeSet);
+    BOOST_CHECK_EQUAL(pool.mapTx.find(c.GetId())->GetAncestorsHeight(), 0UL);
     pool.AddUnchecked(p.GetId(), entry.Fee(Amount(10000LL)).FromTx(p), nullChangeSet);
 
     auto pIdx = [&] { return pool.mapTx.find(p.GetId())->GetInsertionIndex(); };
@@ -448,6 +449,20 @@ BOOST_AUTO_TEST_CASE(MempoolReorgReassignsInsertionIndex) {
 
     // After fixup the parent precedes the child topologically.
     BOOST_CHECK(pIdx() < cIdx());
+
+    // C was accepted while P was confirmed, so reconnecting P must also make
+    // C an unconfirmed descendant rather than leaving its old height of zero.
+    BOOST_CHECK_EQUAL(pool.mapTx.find(c.GetId())->GetAncestorsHeight(), 1UL);
+    BOOST_CHECK(!pool.TransactionWithinChainLimit(c.GetId(), 1));
+
+    // At a height limit of two, D would have height two (P -> C -> D) and
+    // must therefore be rejected. Before the height fixup, C's stale zero
+    // made this check incorrectly succeed.
+    CMutableTransaction d = MakeChildTx(CTransaction(c));
+    CTxMemPool::setEntries ancestors;
+    std::string errString;
+    BOOST_CHECK(!pool.CalculateMemPoolAncestors(
+        entry.Fee(Amount(10000LL)).FromTx(d), ancestors, 2, errString));
 }
 
 BOOST_AUTO_TEST_CASE(MempoolReorgReassignsInsertionIndexForConnectedComponent) {
@@ -496,6 +511,21 @@ BOOST_AUTO_TEST_CASE(MempoolReorgReassignsInsertionIndexForConnectedComponent) {
     BOOST_CHECK(InsertionIndex(pool, b.GetId()) < InsertionIndex(pool, d.GetId()));
     BOOST_CHECK(InsertionIndex(pool, c.GetId()) < InsertionIndex(pool, e.GetId()));
     BOOST_CHECK(InsertionIndex(pool, d.GetId()) < InsertionIndex(pool, e.GetId()));
+
+    // All pre-existing descendants must have heights refreshed across the
+    // reconnected component, including the two-parent descendant e.
+    BOOST_CHECK_EQUAL(pool.mapTx.find(r.GetId())->GetAncestorsHeight(), 0UL);
+    BOOST_CHECK_EQUAL(pool.mapTx.find(a.GetId())->GetAncestorsHeight(), 1UL);
+    BOOST_CHECK_EQUAL(pool.mapTx.find(b.GetId())->GetAncestorsHeight(), 1UL);
+    BOOST_CHECK_EQUAL(pool.mapTx.find(c.GetId())->GetAncestorsHeight(), 2UL);
+    BOOST_CHECK_EQUAL(pool.mapTx.find(d.GetId())->GetAncestorsHeight(), 2UL);
+    BOOST_CHECK_EQUAL(pool.mapTx.find(e.GetId())->GetAncestorsHeight(), 3UL);
+
+    CMutableTransaction f = MakeChildTx(CTransaction(e));
+    CTxMemPool::setEntries ancestors;
+    std::string errString;
+    BOOST_CHECK(!pool.CalculateMemPoolAncestors(
+        entry.Fee(Amount(10000LL)).FromTx(f), ancestors, 4, errString));
 
     CTxMemPool::setEntries descendants;
     pool.CalculateDescendants(pool.mapTx.find(r.GetId()), descendants);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -177,6 +177,13 @@ void CTxMemPool::UpdateTransactionsFromBlock(
     component.insert(addedTransactions.begin(), addedTransactions.end());
     reassignInsertionIndicesNL(component);
 
+    // Re-adding a previously-confirmed parent can make an existing child gain
+    // an unconfirmed ancestor. Recompute heights over the now-topologically
+    // ordered component before any chain-limit checks observe stale values.
+    setEntriesTopoSorted heightsToUpdate;
+    heightsToUpdate.insert(component.begin(), component.end());
+    UpdateAncestorsHeightNL(std::move(heightsToUpdate));
+
     checkJournalAcceptanceNL(affected, nonNullChangeSet.Get());
 }
 

--- a/test/functional/bsv-mempool_ancestorheightlimit.py
+++ b/test/functional/bsv-mempool_ancestorheightlimit.py
@@ -390,6 +390,41 @@ class MempoolAncestorHeightLimits(BitcoinTestFramework):
         assert_equal(len(node.getrawmempool()), 0)
         self.stop_node(0)
 
+    def _test_reorg_refreshes_descendant_height_rpc(self):
+        """Reorg: a re-added parent raises its existing child's chain height."""
+        self.start_node(0, [
+            "-blockmintxfee=0.00001",
+            "-relayfee=0.000005",
+            "-limitancestorcount=2",
+            "-checkmempool=1",
+        ])
+        node = self.nodes[0]
+
+        node.generate(101)
+        utxo = node.listunspent(1)[0]
+
+        funding_txid = utxo["txid"]
+        value = Decimal(str(utxo["amount"]))
+        fee = Decimal("0.0001")
+
+        p, p_value = self._rpc_chain_transaction(
+            node, funding_txid, utxo["vout"], value, fee, 1)
+        block_p = node.generate(1)[0]
+        c, c_value = self._rpc_chain_transaction(node, p, 0, p_value, fee, 1)
+
+        assert_equal(set(node.getrawmempool()), {c})
+
+        node.invalidateblock(block_p)
+        assert_equal(set(node.getrawmempool()), {p, c})
+
+        def send_d():
+            self._rpc_chain_transaction(node, c, 0, c_value, fee, 1)
+
+        assert_raises_rpc_error(
+            -26, "too-long-mempool-chain", send_d)
+        assert_equal(set(node.getrawmempool()), {p, c})
+        self.stop_node(0)
+
     # ====================================================================
     # Main Test Runner
     # ====================================================================
@@ -406,6 +441,7 @@ class MempoolAncestorHeightLimits(BitcoinTestFramework):
         self._test_chain_height_limit_rpc()
         self._test_graph_height_limit_rpc()
         self._test_wide_dag_accepted_rpc()
+        self._test_reorg_refreshes_descendant_height_rpc()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
refresh mempool ancestor heights after reorg