### PR TITLE
fix: prevent undefined pointer arithmetic in SetHex

### DIFF
--- a/src/test/uint256_tests.cpp
+++ b/src/test/uint256_tests.cpp
@@ -111,6 +111,44 @@ BOOST_AUTO_TEST_CASE(basics) {
     BOOST_CHECK(uint160(OneS) == OneS);
 }
 
+BOOST_AUTO_TEST_CASE(sethex_boundary_inputs) {
+    const std::string uint256_123 = std::string(60, '0') + "0123";
+    const std::string uint256_1234 = std::string(60, '0') + "1234";
+    const std::string uint256_111 = std::string(61, '0') + "111";
+    const std::string uint160_123 = std::string(36, '0') + "0123";
+
+    uint256 value;
+    value.SetHex("");
+    BOOST_CHECK(value.IsNull());
+    value.SetHex("g");
+    BOOST_CHECK(value.IsNull());
+    value.SetHex("0x");
+    BOOST_CHECK(value.IsNull());
+    value.SetHex("0X");
+    BOOST_CHECK(value.IsNull());
+    value.SetHex(" \t ");
+    BOOST_CHECK(value.IsNull());
+
+    value.SetHex("123");
+    BOOST_CHECK_EQUAL(value.GetHex(), uint256_123);
+    value.SetHex("1234");
+    BOOST_CHECK_EQUAL(value.GetHex(), uint256_1234);
+    value.SetHex("0x1234");
+    BOOST_CHECK_EQUAL(value.GetHex(), uint256_1234);
+    value.SetHex("123g");
+    BOOST_CHECK_EQUAL(value.GetHex(), uint256_123);
+    value.SetHex("111ggg");
+    BOOST_CHECK_EQUAL(value.GetHex(), uint256_111);
+    value.SetHex("  \t123");
+    BOOST_CHECK_EQUAL(value.GetHex(), uint256_123);
+
+    uint160 small_value;
+    small_value.SetHex("");
+    BOOST_CHECK(small_value.IsNull());
+    small_value.SetHex("123");
+    BOOST_CHECK_EQUAL(small_value.GetHex(), uint160_123);
+}
+
 // <= >= < >
 BOOST_AUTO_TEST_CASE(comparison) {
     uint256 LastL;

--- a/src/uint256.cpp
+++ b/src/uint256.cpp
@@ -37,13 +37,14 @@ template <unsigned int BITS> void base_blob<BITS>::SetHex(const char *psz) {
     const char *pbegin = psz;
     while (::HexDigit(*psz) != -1)
         psz++;
-    psz--;
     uint8_t *p1 = (uint8_t *)data;
     uint8_t *pend = p1 + WIDTH;
-    while (psz >= pbegin && p1 < pend) {
-        *p1 = ::HexDigit(*psz--);
-        if (psz >= pbegin) {
-            *p1 |= uint8_t(::HexDigit(*psz--) << 4);
+    // psz points one past the last hex digit. Only decrement it after
+    // confirming that a digit remains to be decoded.
+    while (psz != pbegin && p1 < pend) {
+        *p1 = ::HexDigit(*--psz);
+        if (psz != pbegin) {
+            *p1 |= uint8_t(::HexDigit(*--psz) << 4);
             p1++;
         }
     }


### PR DESCRIPTION
This PR fixes undefined behavior caused by pointer arithmetic in src/uint256.cpp: base_blob::SetHex() and adds regression tests for empty and boundary inputs.